### PR TITLE
Fixed Auto Publishing A Tagged Image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
                   command: |
                       echo "Publishing tag << pipeline.git.tag >>"
                       export BUILD_VER="<< pipeline.git.tag >>"
-                      if [ -z ${BUILD_VER}" ]; then
+                      if [ -z "${BUILD_VER}" ]; then
                           echo "cannot publish a Docker image, release-tag is empty"
                           exit 1
                       fi


### PR DESCRIPTION
fix: Auto publishing a new image on tag release in the CI.