### PR TITLE
Upgrade Multiple Versions To Their Latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 #STAGE: Install Tool for CircleCI environment plus some
-FROM khalifahks/alpine-glibc:2.34-r0 AS base
+FROM kohirens/alpine-glibc:3.17-2.35-r1 AS base
 
-ARG GH_CLI_VER='2.5.2'
-ARG GTB_CLI_VER='1.2.9'
+ARG GH_CLI_VER='2.31.0'
+ARG GTB_CLI_VER='2.1.2'
 
 RUN apk --progress --purge --no-cache upgrade \
  && apk --no-progress --purge --no-cache add --upgrade \
     bash \
+    curl \
     docker \
+    gettext \
     git \
     openssh \
     tar \


### PR DESCRIPTION
* Added gettext for so many reasons.
* Upgraded GLib-C base image to Alpine 3.17 and GLib-C to version 2.35-r1.
* Upgraded git-tool-belt to version 2.2.0.
* Upgraded GitHub CLI to version 2.31.0.